### PR TITLE
memory leaks fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps

--- a/IMSProg_programmer/dialoginfo.cpp
+++ b/IMSProg_programmer/dialoginfo.cpp
@@ -6,10 +6,22 @@ DialogInfo::DialogInfo(QWidget *parent) :
     ui(new Ui::DialogInfo)
 {
     ui->setupUi(this);
+
+    pix24 = new QPixmap(":/res/img/ch341_24.png");
+    pix93 = new QPixmap(":/res/img/ch341_93.png");
+    pix25 = new QPixmap(":/res/img/ch341_spi.png");
+    pix2518 = new QPixmap(":/res/img/ch341_spi_18.png");
+    pixnone = new QPixmap(":/res/img/ch341_unknown.png");
+
 }
 
 DialogInfo::~DialogInfo()
 {
+    delete pix24;
+    delete pix93;
+    delete pix25;
+    delete pix2518;
+    delete pixnone;
     delete ui;
 }
 void DialogInfo::on_pushButton_clicked()
@@ -18,12 +30,6 @@ void DialogInfo::on_pushButton_clicked()
 }
 void DialogInfo::setChip(const uint chipType)
 {
-   QPixmap *pix24 = new QPixmap(":/res/img/ch341_24.png");
-   QPixmap *pix93 = new QPixmap(":/res/img/ch341_93.png");
-   QPixmap *pix25 = new QPixmap(":/res/img/ch341_spi.png");
-   QPixmap *pix2518 = new QPixmap(":/res/img/ch341_spi_18.png");
-   QPixmap *pixnone = new QPixmap(":/res/img/ch341_unknown.png");
-
    switch (chipType)
    {
      case 1:

--- a/IMSProg_programmer/dialoginfo.h
+++ b/IMSProg_programmer/dialoginfo.h
@@ -21,6 +21,13 @@ private slots:
 
 private:
     Ui::DialogInfo *ui;
+
+    QPixmap *pix24;
+    QPixmap *pix93;
+    QPixmap *pix25;
+    QPixmap *pix2518;
+    QPixmap *pixnone;
+
 };
 
 #endif // DIALOGINFO_H

--- a/IMSProg_programmer/dialogsfdp.cpp
+++ b/IMSProg_programmer/dialogsfdp.cpp
@@ -25,8 +25,11 @@ void DialogSFDP::on_pushButton_clicked()
     uint32_t sfdpBlockSize = 0;
     bool sfdpSupport = false;
     unsigned char i, imax, twoAreaAddress=0xff, manufAreaAddress=0xff, twoAreaLen = 0xff, manAreaLen = 0xff;
-    uint8_t *sfdpBuf, jedecMan=0xff, idSize;
-    sfdpBuf = (uint8_t *)malloc(256);
+    uint8_t jedecMan=0xff, idSize;
+
+    // memory leak in sfdpBuf = (uint8_t *)malloc(256);
+    std::shared_ptr<unsigned char[]> sfdpBuf(new unsigned char[256]);
+
     QString regData = "", VCCmin = "", VCCmax = "", speeds = "Single", addrTxt="";
     int retval = 0;
     stCH341 = ch341a_spi_init();
@@ -42,7 +45,7 @@ void DialogSFDP::on_pushButton_clicked()
         //Reading JEDEC ID
         SPI_CONTROLLER_Chip_Select_Low();
         SPI_CONTROLLER_Write_One_Byte(0x9f);
-        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf,3,SPI_CONTROLLER_SPEED_SINGLE);
+        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf.get(),3,SPI_CONTROLLER_SPEED_SINGLE);
         SPI_CONTROLLER_Chip_Select_High();
         if (retval)
         {
@@ -62,7 +65,7 @@ void DialogSFDP::on_pushButton_clicked()
         SPI_CONTROLLER_Write_One_Byte(0x00);
         SPI_CONTROLLER_Write_One_Byte(0x00);
         SPI_CONTROLLER_Write_One_Byte(0x00);
-        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf,256,SPI_CONTROLLER_SPEED_SINGLE);
+        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf.get(),256,SPI_CONTROLLER_SPEED_SINGLE);
         SPI_CONTROLLER_Chip_Select_High();
         if (retval)
         {
@@ -165,7 +168,7 @@ void DialogSFDP::on_pushButton_clicked()
         //READING STATUS REGISTER 0
         SPI_CONTROLLER_Chip_Select_Low();
         SPI_CONTROLLER_Write_One_Byte(0x05);
-        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf,2,SPI_CONTROLLER_SPEED_SINGLE);
+        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf.get(),2,SPI_CONTROLLER_SPEED_SINGLE);
         SPI_CONTROLLER_Chip_Select_High();
         usleep(1);
         if (retval)
@@ -184,7 +187,7 @@ void DialogSFDP::on_pushButton_clicked()
         //READING STATUS REGISTER 1
         SPI_CONTROLLER_Chip_Select_Low();
         SPI_CONTROLLER_Write_One_Byte(0x35);
-        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf,2,SPI_CONTROLLER_SPEED_SINGLE);
+        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf.get(),2,SPI_CONTROLLER_SPEED_SINGLE);
         SPI_CONTROLLER_Chip_Select_High();
         usleep(1);
         if (retval)
@@ -218,7 +221,7 @@ void DialogSFDP::on_pushButton_clicked()
         SPI_CONTROLLER_Write_One_Byte(0x00);
         SPI_CONTROLLER_Write_One_Byte(0x00);
         SPI_CONTROLLER_Write_One_Byte(0x00);
-        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf,16,SPI_CONTROLLER_SPEED_SINGLE);
+        retval = SPI_CONTROLLER_Read_NByte(sfdpBuf.get(),16,SPI_CONTROLLER_SPEED_SINGLE);
         SPI_CONTROLLER_Chip_Select_High();
         if (retval)
         {
@@ -261,12 +264,11 @@ void DialogSFDP::on_pushButton_3_clicked()
 {
    if (numOfRegisters < 2)
    {
-    int stCH341 = 0, retval;
+    int stCH341 = 0;
     stCH341 = ch341a_spi_init();
     if (stCH341 == 0)
     {
-       uint8_t *sfdpBuf, r0, r1;
-       sfdpBuf = (uint8_t *)malloc(4);
+       uint8_t r0, r1;
        r0 = 0;
        r1 = 0;
        if (QString::compare(ui->lineEdit_sr07->text(), "0", Qt::CaseInsensitive)) r0 = r0 + 128;

--- a/IMSProg_programmer/mainwindow.cpp
+++ b/IMSProg_programmer/mainwindow.cpp
@@ -179,6 +179,10 @@ void MainWindow::on_pushButton_clicked()
 
        ui->pushButton->setStyleSheet(redKeyStyle);
        ui->statusBar->showMessage(tr("Reading data from ") + ui->comboBox_name->currentText());
+
+       chipData.resize(int(currentChipSize));
+       chipData.fill(0xff);
+
        for (k = 0; k < currentNumBlocks; k++)
        {
            switch (currentChipType)
@@ -240,6 +244,7 @@ void MainWindow::on_pushButton_clicked()
 //                  chipData[addr + j] = char(buf[addr + j - k * currentBlockSize]);
              chipData[addr + j] = static_cast<char>(buf[j]);
             }
+
           addr = addr + currentBlockSize;
           curBlock++;
           if (curBlock * currentBlockSize < 413300) hexEdit->setData(chipData); //show buffer in hehedit while chip data is being loaded
@@ -623,6 +628,9 @@ void MainWindow::on_actionOpen_triggered()
     ui->crcEdit->setText(getCRC32());
 }
 
+/**
+ * @brief MainWindow::on_actionWrite_triggered "Write" action
+ */
 void MainWindow::on_actionWrite_triggered()
 {
     //Writting data to chip
@@ -654,7 +662,16 @@ void MainWindow::on_actionWrite_triggered()
         //progerssbar settings
         ui->progressBar->setRange(0, static_cast<int>(currentNumBlocks));
         ui->checkBox_2->setStyleSheet("QCheckBox{font-weight:800;}");
+
         chipData = hexEdit->data();
+        const auto s = chipData.size();
+        int diff = int(currentChipSize) - hexEdit->data().size();
+        if (diff > 0) {
+            chipData.insert(s, diff, 0xff);
+        }
+        const auto s1 = chipData.size();
+        qDebug() << "chipData.size() before : " << s << " after: " << s1 << "\n";
+
     //uint8_t buf[currentBlockSize];
 // memory leaks in buf
 // uint8_t *buf;

--- a/IMSProg_programmer/mainwindow.h
+++ b/IMSProg_programmer/mainwindow.h
@@ -96,6 +96,12 @@ private slots:
     void on_actionChip_info_triggered();
 
 private:
+    enum class chipType : uint8_t {chipTypeSPI = 0U,
+                                   chipType25EE,
+                                   chipType93EE,
+                                   chipType24EE,
+                                   chipType95EE};
+
     Ui::MainWindow *ui;
     QColor defaultTextColor;
     QString grnKeyStyle, redKeyStyle;
@@ -103,7 +109,8 @@ private:
     int statusCH341;
     QByteArray chipData;
     uint32_t currentChipSize, currentNumBlocks, currentBlockSize, currentPageSize;
-    uint8_t currentAlgorithm, currentChipType;
+    uint8_t currentAlgorithm;
+    chipType currentChipType;
     unsigned int currentAddr4bit;
     bool isHalted;
     QString bytePrint(unsigned char z);


### PR DESCRIPTION
Hi!
I have noticed that a number of possible memory leaks may happen in the project. I fixed that, mostly using std::shared_ptr instead of raw pointers.
It adds tiny overhead but automates memory deallocation at scope exit.

Also I have added 
```
enum class chipType : uint8_t {chipTypeSPI = 0U,
                                   chipType25EE,
                                   chipType93EE,
                                   chipType24EE,
                                   chipType95EE};
```
instead of anonymous numbers to ease control flow management in the program.