### PR TITLE
Some improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,0 +1,71 @@
+name: "Report bug"
+description: "Create a bug report to help this project improve"
+labels: ["bug"]
+body:
+- type: markdown
+  attributes:
+      value: |
+        ### Thank you for contributing to this project!
+        Before create a new bug report please search and check there isn't a duplicate already present.
+- type: input
+  id: distribution
+  validations:
+      required: true
+  attributes:
+      label: Distribution
+      description: Provide the distribution and its version
+      value: For example Debian 12, Ubuntu 22.04, Fedora 37 etc...
+- type: input
+  id: architecture
+  validations:
+      required: true
+  attributes:
+      label: Architecture
+      description: Provide the architecture
+      value: For example amd64, armhf, arm64 etc...
+- type: input
+  id: kernel-version
+  validations:
+      required: false
+  attributes:
+      label: Kernel version
+      description: |
+        Provide the kernel version used, if from distribution also the package version.
+        Can be useful "uname -a" output
+      value: For example 5.15 from ubuntu package 5.15.0-56.62~20.04.1
+- type: input
+  id: imsprog-version
+  validations:
+      required: true
+  attributes:
+      label: IMSProg version
+      description: |
+        Provide the IMSProg version used
+        Please specify git commit used for build out of tagged version
+      value: For example version 1.1.6 or commit c763e58
+- type: textarea
+  id: bug-description
+  validations:
+      required: true
+  attributes:
+      label: Bug description
+      description: |
+        Provide a description of the bug you're found.
+        Please don't expect anyone to guess everything but give enough information.
+- type: textarea
+  id: reproduce
+  attributes:
+      label: Steps to reproduce
+      description: Describe the steps to reproduce the bug (when possible).
+- type: textarea
+  id: expected-behavior
+  attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen instead.
+- type: textarea
+  id: additional-info
+  attributes:
+      label: Additional information
+      description: Add any additional information related to the issue here.
+
+

--- a/.github/ISSUE_TEMPLATE/Feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest a new feature or an improvement for this project
+labels: ["enhancement"]
+body:
+- type: markdown
+  attributes:
+      value: |
+        ### Thank you for contributing to this project!
+        Before please search and check there isn't a duplicate already present.
+- type: textarea
+  id: description
+  validations:
+      required: true
+  attributes:
+      label: Description
+      description: |
+        Provide a description of a feature request or an improvement that you want suggest.
+- type: textarea
+  id: usage-tips
+  validations:
+      required: true
+  attributes:
+      label: Usage tips
+      description: |
+        Please keep this notes for other contributors
+      value: |
+        * Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are interested into this.
+        * Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this.
+        * Subscribe to receive notifications on status change and new comments, you can do also without add comment.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,15 @@ name: Build
 
 on:
   push:
-    branches:
-      - "*"
+    branches-ignore:
+      - "debian/**"
     paths-ignore:
       - "README.md"
       - "**/README.md"
       - "**/index.html"
   pull_request:
-    branches:
-      - "*"
+    branches-ignore:
+      - "debian/**"
     paths-ignore:
       - "README.md"
       - "**/README.md"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,91 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - "*"
+    paths-ignore:
+      - "README.md"
+      - "**/README.md"
+      - "**/index.html"
+  pull_request:
+    branches:
+      - "*"
+    paths-ignore:
+      - "README.md"
+      - "**/README.md"
+      - "**/index.html"
+  workflow_dispatch:
+
+jobs:
+  amd64:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [Ubuntu-20, Ubuntu-22, Debian-11, Debian-12, Debian-Testing, Debian-Experimental]
+        cpp_compiler: [g++]
+        include:
+          - name: Ubuntu-20
+            # Uses gcc 9.3.0, clang 10.0.0, cmake 3.16.3
+            image: "ubuntu:20.04"
+            ubuntu: 20
+          - name: Ubuntu-22
+            # Uses gcc 12.2.0, clang 15.0.7, cmake 3.24.2
+            image: "ubuntu:22.04"
+            ubuntu: 22
+          - name: Debian-11
+            # Uses gcc 10.2.1, clang 11.0.1, cmake 3.18.4
+            image: "debian:bullseye"
+          - name: Debian-11
+            image: "debian:bullseye"
+            c_compiler: clang
+            cpp_compiler: clang++
+          - name: Debian-12
+            # Uses gcc 12.2.0, clang 15.0.6, cmake 3.25.1
+            image: "debian:bookworm"
+          - name: Debian-12
+            image: "debian:bookworm"
+            c_compiler: clang
+            cpp_compiler: clang++
+          - name: Debian-Testing
+            image: "debian:testing"
+          - name: Debian-Testing
+            image: "debian:testing"
+            c_compiler: clang
+            cpp_compiler: clang++
+          - name: Debian-Experimental
+            image: "debian:experimental"
+          - name: Debian-Experimental
+            image: "debian:experimental"
+            c_compiler: clang
+            cpp_compiler: clang++
+    container:
+      image: ${{ matrix.image }}
+      env:
+        LANG: en_US.UTF-8
+        BUILD_TYPE: ${{ matrix.build_type }}
+        CC: ${{ matrix.c_compiler }}
+        CXX: ${{ matrix.cpp_compiler }}
+        WITH_PROJ: ON
+        APT_LISTCHANGES_FRONTEND: none
+        DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Install packages required
+        shell: bash
+        run: |
+          apt-get update -qq
+          apt-get install -yq \
+            clang \
+            cmake \
+            g++ \
+            libusb-1.0-0-dev \
+            qtbase5-dev \
+            pkg-config
+      - uses: actions/checkout@v4
+      - name: Build
+        working-directory: .
+        run: |
+          cmake .
+          make
+          make install

--- a/IMSProg_editor/CMakeLists.txt
+++ b/IMSProg_editor/CMakeLists.txt
@@ -9,8 +9,6 @@ set(CMAKE_AUTOUIC ON)
 
 project(IMSProg_editor LANGUAGES CXX)
 
-include(GNUInstallDirs)
-
 # Set the CMAKE_INSTALL_PREFIX to /usr if not specified
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "The default install prefix" FORCE)

--- a/IMSProg_programmer/CMakeLists.txt
+++ b/IMSProg_programmer/CMakeLists.txt
@@ -9,8 +9,6 @@ set(CMAKE_AUTOUIC ON)
 
 project(IMSProg LANGUAGES C CXX)
 
-include(GNUInstallDirs)
-
 # Set the CMAKE_INSTALL_PREFIX to /usr if not specified
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "The default install prefix" FORCE)

--- a/README.md
+++ b/README.md
@@ -53,13 +53,18 @@ For build are needed:
 - udev
 
 On Debian and derivates:
+
 `sudo apt-get install cmake libusb-1.0-0-dev qtbase5-dev pkg-config`
+
 On Debian >=13 and Ubuntu >=23.10:
+
 `sudo apt-get install systemd-dev`
+
 On older:
+
 `sudo apt-get install udev`
 
-Optionally if you want use the chip database update script
+Optionally if you want use the chip database update script:
 - zenity
 - wget
 

--- a/README.md
+++ b/README.md
@@ -44,25 +44,26 @@ sudo make install
 These commands are included in the `build_all.sh` file.
 
 ## System software requirements
-- cmake library
-  
-`sudo apt install cmake`
 
-- libusb library
-
-`sudo apt-get install libusb-1.0-0 libusb-dev libusb-1.0-0-dev`
-
-- Qt5 library
-
-`sudo apt-get install qtbase5-dev`
-
+For build are needed:
+- cmake
+- libusb 1.0
+- Qt5
 - pkg config
+- udev
 
-`sudo apt-get install pkg-config`
+On Debian and derivates:
+`sudo apt-get install cmake libusb-1.0-0-dev qtbase5-dev pkg-config`
+On Debian >=13 and Ubuntu >=23.10:
+`sudo apt-get install systemd-dev`
+On older:
+`sudo apt-get install udev`
 
-- zenity (Only needed for the chip database update script)
+Optionally if you want use the chip database update script
+- zenity
+- wget
 
-`sudo apt install zenity`
+`sudo apt-get install zenity wget`
 
 ## How to use:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Optionally if you want use the chip database update script
 
 `sudo apt-get install zenity wget`
 
+:information_source: Debian < 11 and Ubuntu < 20.04 are not supported, you may unable to have it working on them.
+
 ## How to use:
 
 ### Connecting


### PR DESCRIPTION
- add github workflow for testing build
this tests any push and PR building on many systems and different
configurations for help find regression
- build: remove include(GNUInstallDirs)
add of it caused default of CMAKE_INSTALL_SYSCONFDIR to /usr/etc
default of all paths, if not defined, are present, so I think should be
ok and better remove it
- Readme: improve requirements part
- github: add issues templates for bug report and feature request
