### PR TITLE
[doc] change main header size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IMSProg
+## IMSProg
 
 * [System software requirements](#system-software-requirements)
 * [How to use](#how-to-use)


### PR DESCRIPTION
I change main header size because in some markdown readers your header will be IMSPROG. For example ghostwriter view:
![image](https://github.com/bigbigmdm/IMSProg/assets/27889022/7ac84700-c738-4159-8d74-56acd64baaca)

Or you like IMSPROG?
