### PR TITLE
add Clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ These commands are included in the `build_all.sh` file.
 ## System software requirements
 
 For build are needed:
-- cmake
+- CMake
 - libusb 1.0
 - Qt5
 - pkg config

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These commands are included in the `build_all.sh` file.
 ## System software requirements
 
 For build are needed:
+- Clang
 - CMake
 - libusb 1.0
 - Qt5
@@ -64,7 +65,7 @@ For build are needed:
 
 On Debian and derivatives:
 
-`sudo apt-get install cmake libusb-1.0-0-dev qtbase5-dev pkg-config`
+`sudo apt-get install cmake clang libusb-1.0-0-dev qtbase5-dev pkg-config`
 
 On Debian >=13 and Ubuntu >=23.10:
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Menu `File`.
 - `Open` or `[Ctrl+O]` or ![open](IMSProg_editor/img/open.png) allows you to load the data file.
 - `Save` or `[Ctrl+S]` or ![save](IMSProg_editor/img/save.png) saves the chip parameter table to a database file.
 - `Exit` or `[Ctrl+X]` or ![exit](IMSProg_editor/img/exit.png) - exits the editor.
-- `Export to CSV format` or `[Ctrl+X]` or ![export](IMSProg_editor/img/tocsv.png) allows to unload data about chips in CSV format for further processing by spreadsheet programme - Libre Office Calc, Open Office Calc, Google Tables, etc.
+- `Export to CSV format` or `[Ctrl+X]` or ![export](IMSProg_editor/img/tocsv.png) allows to unload data about chips in CSV format for further processing by spreadsheet software - LibreOffice Calc, OpenOffice Calc, Google Tables, etc.
 - `Import from CSV file` or `[Ctrl+Shift+X]` or ![import](IMSProg_editor/img/import.png) - loads a table in CSV format and adds data from it to the existing data in the table.
 
 Menu `Edit`.


### PR DESCRIPTION
tested with clear Ubuntu 22

original
`sudo apt-get install cmake libusb-1.0-0-dev qtbase5-dev pkg-config`
is not enough

Optionally you can use `sudo apt-get install g++` instead of `sudo apt-get install clang`