### PR TITLE
Add a way to install / update IMSProg without root (still requires root for udev rules)

### DIFF
--- a/IMSProg_programmer/CMakeLists.txt
+++ b/IMSProg_programmer/CMakeLists.txt
@@ -41,28 +41,30 @@ find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
 find_package(Qt5Widgets REQUIRED)
 find_package(LibUSB REQUIRED)
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-set(UDEVDIR "/usr/lib/udev")
-if (CMAKE_INSTALL_PREFIX STREQUAL "/usr" OR CMAKE_INSTALL_PREFIX STREQUAL "/" )
-# /usr and / install prefixes at treated by cmake GNUInstallDirs as
-# synonym for "system location". In this case we can look up the correct udevdir
-# using pkg-config.
-# See: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases
-find_package(PkgConfig)
-  if (PKG_CONFIG_FOUND)
-    pkg_check_modules( PKGCONFIG_UDEV udev)
-    if (PKGCONFIG_UDEV_FOUND)
-      execute_process(
-        COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=udevdir udev
-          OUTPUT_VARIABLE PKGCONFIG_UDEVDIR
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
-      if(PKGCONFIG_UDEVDIR)
-        file(TO_CMAKE_PATH "${PKGCONFIG_UDEVDIR}" UDEVDIR)
+if(NOT DEFINED UDEVDIR)
+  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(UDEVDIR "/usr/lib/udev")
+    if (CMAKE_INSTALL_PREFIX STREQUAL "/usr" OR CMAKE_INSTALL_PREFIX STREQUAL "/" )
+      # /usr and / install prefixes at treated by cmake GNUInstallDirs as
+      # synonym for "system location". In this case we can look up the correct udevdir
+      # using pkg-config.
+      # See: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases
+      find_package(PkgConfig)
+      if (PKG_CONFIG_FOUND)
+        pkg_check_modules( PKGCONFIG_UDEV udev)
+        if (PKGCONFIG_UDEV_FOUND)
+          execute_process(
+            COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=udevdir udev
+              OUTPUT_VARIABLE PKGCONFIG_UDEVDIR
+              OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+          if(PKGCONFIG_UDEVDIR)
+            file(TO_CMAKE_PATH "${PKGCONFIG_UDEVDIR}" UDEVDIR)
+          endif()
+        endif()
       endif()
     endif()
   endif()
-endif()
 endif()
 # Qt5LinguistTools
 find_package(Qt5 REQUIRED COMPONENTS LinguistTools)

--- a/build_all_non_root_ubuntu.sh
+++ b/build_all_non_root_ubuntu.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+export HOME_DIR=$(readlink -f ~)
+export CMAKE_INSTALL_BINDIR=$HOME_DIR/.local/bin
+export CMAKE_INSTALL_DATAROOTDIR=$HOME_DIR/.imsprog
+export UDEVDIR="$CMAKE_INSTALL_DATAROOTDIR"/udev
+export LOCAL_APP_DIR=$HOME_DIR/.local/share/applications
+
+[[ "$OSTYPE" == "darwin"* ]] && export C_INCLUDE_PATH=/usr/local/opt/libusb/include
+(
+cd IMSProg_programmer
+rm -rf build/
+mkdir build/
+cmake -S . -B build/ -DCMAKE_INSTALL_BINDIR=$CMAKE_INSTALL_BINDIR -DCMAKE_INSTALL_DATAROOTDIR=$CMAKE_INSTALL_DATAROOTDIR -DUDEVDIR=$UDEVDIR
+cmake --build build/ --parallel
+cmake --install build/
+rm -rf build/
+
+
+rm -f $LOCAL_APP_DIR/IMSProg.desktop $LOCAL_APP_DIR/IMSProg_database_update.desktop
+cp $CMAKE_INSTALL_DATAROOTDIR/applications/IMSProg.desktop $LOCAL_APP_DIR/IMSProg.desktop
+cp $CMAKE_INSTALL_DATAROOTDIR/applications/IMSProg_database_update.desktop $LOCAL_APP_DIR/IMSProg_database_update.desktop
+
+# patch desktop files
+sed -i "s|/usr/bin|${CMAKE_INSTALL_BINDIR}|g" "$LOCAL_APP_DIR/IMSProg.desktop"
+sed -i "s|/usr/share/pixmaps/IMSProg64.png|${CMAKE_INSTALL_DATAROOTDIR}/pixmaps/IMSProg64.png|g" "$LOCAL_APP_DIR/IMSProg.desktop"
+
+sed -i "s|/usr/bin|${CMAKE_INSTALL_BINDIR}|g" "$LOCAL_APP_DIR/IMSProg_database_update.desktop"
+sed -i "s|/usr/share/pixmaps/IMSProg_database_update.png|${CMAKE_INSTALL_DATAROOTDIR}/pixmaps/IMSProg_database_update.png|g" "$LOCAL_APP_DIR/IMSProg_database_update.desktop"
+)
+(
+cd IMSProg_editor
+rm -rf build/
+mkdir build/
+cmake -S . -B build/ -DCMAKE_INSTALL_BINDIR=$CMAKE_INSTALL_BINDIR -DCMAKE_INSTALL_DATAROOTDIR=$CMAKE_INSTALL_DATAROOTDIR
+cmake --build build/ --parallel
+cmake --install build/
+rm -rf build/
+
+
+rm -f $LOCAL_APP_DIR/IMSProg_editor.desktop
+cp $CMAKE_INSTALL_DATAROOTDIR/applications/IMSProg_editor.desktop $LOCAL_APP_DIR/IMSProg_editor.desktop
+
+# patch desktop files
+sed -i "s|/usr/bin|${CMAKE_INSTALL_BINDIR}|g" "$LOCAL_APP_DIR/IMSProg_editor.desktop"
+sed -i "s|/usr/share/pixmaps/chipEdit64.png|${CMAKE_INSTALL_DATAROOTDIR}/pixmaps/chipEdit64.png|g" "$LOCAL_APP_DIR/IMSProg_editor.desktop"
+)
+
+# Reloading the USB rules or creating the app bundles for macOS
+[[ "$OSTYPE" != "darwin"* ]] && echo "
+Finished building
+
+In order to allow non-root users access to the programmer please run the following commands as root:
+cp ${UDEVDIR}/rules.d/71-CH341.rules /usr/lib/udev/rules.d
+udevadm control --reload-rules
+" || ./create_macos_appbundles.sh


### PR DESCRIPTION
I added a way of building the source that does not need root privileges.

Feel free to use whatever is suitable. The current script is tailored towards ubuntu.

The changes that I had to do:
- Allow changing of the target directory for udev rules
- Set various variables to direct CMake to a folder inside the home directory
- Update the .desktop files to contain the new paths