### PR TITLE
Fix events for combobox_page_change

### DIFF
--- a/IMSProg_programmer/mainwindow.cpp
+++ b/IMSProg_programmer/mainwindow.cpp
@@ -523,6 +523,7 @@ void MainWindow::on_comboBox_page_currentIndexChanged(int index)
 {
     currentChipSize = ui->comboBox_size->currentData().toUInt();
     currentBlockSize = ui->comboBox_block->currentData().toUInt();
+    currentPageSize = ui->comboBox_page->currentData().toUInt();
     currentAddr4bit = ui->comboBox_addr4bit->currentData().toUInt();
     if ((currentChipSize !=0) && (currentBlockSize!=0) && (currentChipType ==0))
     {


### PR DESCRIPTION
The "MainWindow::on_comboBox_page_currentIndexChanged" function does not change the currentPageSize

Thus if the change of the page size is inputted last, the read / write opperation will use the wrong value.


Also a note:
Is there a reason, why every event, updates all internal values? In my opinion this produces a lot of duplicated code.

One way to fix this would be to use a single function that gets called from all other events or that every event only changes the respective internal value (e.g. on_comboBox_page_currentIndexChanged only updates the currentPageSize)