### PR TITLE
Fix: Incorrect install dir for udev while cross compiling

### DIFF
--- a/IMSProg_programmer/CMakeLists.txt
+++ b/IMSProg_programmer/CMakeLists.txt
@@ -43,7 +43,7 @@ find_package(LibUSB REQUIRED)
 
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 set(UDEVDIR "/usr/lib/udev")
-if (CMAKE_INSTALL_PREFIX STREQUAL "/usr" OR CMAKE_INSTALL_PREFIX STREQUAL "/" )
+if (CMAKE_INSTALL_PREFIX STREQUAL "/usr" OR CMAKE_INSTALL_PREFIX STREQUAL "/" AND NOT CMAKE_CROSSCOMPILING)
 # /usr and / install prefixes at treated by cmake GNUInstallDirs as
 # synonym for "system location". In this case we can look up the correct udevdir
 # using pkg-config.


### PR DESCRIPTION
Fixed install dir for udev rules file while [cross compiling](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html).