### PR TITLE
Fix standard paths lookups

### DIFF
--- a/IMSProg_programmer/CMakeLists.txt
+++ b/IMSProg_programmer/CMakeLists.txt
@@ -12,6 +12,10 @@ project(IMSProg LANGUAGES C CXX)
 include(FindPkgConfig)
 pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_INSTALL_DO_STRIP FALSE)
+endif()
+
 # Set the CMAKE_INSTALL_PREFIX to /usr if not specified
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/IMSProg_programmer/main.cpp
+++ b/IMSProg_programmer/main.cpp
@@ -20,27 +20,43 @@
 int main(int argc, char *argv[])
 {
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication a(argc, argv);
+    QCoreApplication::setApplicationName("imsprog");
     QFont font("Monospace");
     font.setStyleHint(QFont::TypeWriter);
     font.setPointSize(12);
     QApplication::setFont(font);
-    QApplication a(argc, argv);
-    QCoreApplication::setApplicationName("imsprog");
     QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    QStringList foundPaths;
+    QString binRelPath = QCoreApplication::applicationDirPath() + "/../share/" + QCoreApplication::applicationName();
+    allPaths.insert(1, QDir::cleanPath(binRelPath));
+
+    QString localeName = QLocale::system().name();
+    QString translateName = "chipProgrammer_" + localeName;
+    qDebug() << "localeName = " << localeName << ", translateName = " << translateName;
 
     foreach (const QString &path, allPaths)
     {
-        QString fullPath = path + "/chipProgrammer_de_DE.qm";
-        QFile datfile(fullPath);
-        if (QFileInfo(datfile).exists()) foundPaths << path;
+        QString fullPath = QDir(path).filePath(translateName + ".qm");
+        qDebug() << "Trying " << fullPath;
+
+        if (QFile::exists(fullPath))
+        {
+            qDebug() << "Found translation file:" << fullPath;
+            QTranslator *translator = new QTranslator(&a);
+
+            if (translator->load(translateName, path))
+            {
+                a.installTranslator(translator);
+                qDebug() << "Installed" << translateName << "from" << path;
+                break;
+            }
+            else
+            {
+                delete translator; 
+            }
+        }
     }
 
-     // translation path is foundPaths.first();
-    QTranslator translator;
-        QString translateName = "chipProgrammer_" + QLocale::system().name();
-        if(translator.load(translateName, foundPaths.first())) a.installTranslator(&translator);
-        a.installTranslator(&translator);
     QStringList cmdline_args = QCoreApplication::arguments();
     MainWindow w;
     w.show();

--- a/IMSProg_programmer/main.cpp
+++ b/IMSProg_programmer/main.cpp
@@ -27,7 +27,8 @@ int main(int argc, char *argv[])
     font.setPointSize(12);
     QApplication::setFont(font);
     QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    QString binRelPath = QCoreApplication::applicationDirPath() + "/../share/" + QCoreApplication::applicationName();
+    QDir binDir(QCoreApplication::applicationDirPath());
+    QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
     allPaths.insert(1, QDir::cleanPath(binRelPath));
 
     QString localeName = QLocale::system().name();

--- a/IMSProg_programmer/mainwindow.cpp
+++ b/IMSProg_programmer/mainwindow.cpp
@@ -1997,10 +1997,10 @@ void MainWindow::progInit()
     int index2;
     ui->statusMessage->setText(tr("Opening DAT file"));
 
-    QCoreApplication::setApplicationName("imsprog");
     QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    QString binRelPath = QCoreApplication::applicationDirPath() + "/../share/" + QCoreApplication::applicationName();
-    allPaths.insert(1, QDir::cleanPath(binRelPath));
+    QDir binDir(QCoreApplication::applicationDirPath());
+    QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
+    allPaths.insert(1, binRelPath);
     // allPaths is now
     // - user-specific directory
     // - share directory relative to IMSProg executable
@@ -2010,13 +2010,14 @@ void MainWindow::progInit()
     QFile datfile;
     foreach (const QString &dir, allPaths)
     {
-        datfile.setFileName(dir + "/IMSProg.Dat");
-        if (QFileInfo(datfile).exists()) {
+        QString fullPath = QDir(dir).filePath("IMSProg.Dat");
+        if (QFile::exists(fullPath)) {
+            datfile.setFileName(fullPath);
             break;
         }
     }
 
-    if (datfile.fileName().isEmpty() || !QFileInfo(datfile).exists()) {
+    if (datfile.fileName().isEmpty()) {
         QMessageBox::about(this, tr("Error"), tr("The chip database file was not found!"));
         return;
     }

--- a/IMSProg_programmer/mainwindow.cpp
+++ b/IMSProg_programmer/mainwindow.cpp
@@ -1999,29 +1999,37 @@ void MainWindow::progInit()
 
     QCoreApplication::setApplicationName("imsprog");
     QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    QStringList foundPaths;
+    QString binRelPath = QCoreApplication::applicationDirPath() + "/../share/" + QCoreApplication::applicationName();
+    allPaths.insert(1, QDir::cleanPath(binRelPath));
+    // allPaths is now
+    // - user-specific directory
+    // - share directory relative to IMSProg executable
+    // - standard locations
 
-    foreach (const QString &path, allPaths)
+    // use the first chip database file found
+    QFile datfile;
+    foreach (const QString &dir, allPaths)
     {
-        QString fullPath = path + "/IMSProg.Dat";
-        QFile datfile(fullPath);
-        if (QFileInfo(datfile).exists()) foundPaths << fullPath;
+        datfile.setFileName(dir + "/IMSProg.Dat");
+        if (QFileInfo(datfile).exists()) {
+            break;
+        }
     }
 
-    if (foundPaths.isEmpty())
-    {
+    if (datfile.fileName().isEmpty() || !QFileInfo(datfile).exists()) {
         QMessageBox::about(this, tr("Error"), tr("The chip database file was not found!"));
         return;
     }
-     // local path is foundPaths.first();
-     // system path is foundPaths.last();
-     // if local path was not found foundPaths.first() is system path
 
-    QFile datfile(foundPaths.first());
+    qDebug() << "Using chip database file " << datfile.fileName();
     QByteArray dataChips;
     if (!datfile.open(QIODevice::ReadOnly))
     {
-        QMessageBox::about(this, tr("Error"), tr("Error loading chip database file!"));
+        QString msg = tr("Error loading chip database file!\nFile: %1\nError Code: %2\nReason: %3")
+                      .arg(datfile.fileName())
+                      .arg(static_cast<int>(datfile.error()))
+                      .arg(datfile.errorString());
+        QMessageBox::about(this, tr("Error"), msg);
         return;
     }
     dataChips = datfile.readAll();


### PR DESCRIPTION
Account for relative-to-binary ../share/ when considering locations for resources; load in specific order:

- user's own self-controlled app-specific location
- app-relative location (for non-system-location installations or portable applications)
- system locations

This also fixes a hard crash when installed into a non-system location.

--

Pretty much as it says on the tin. You probably want to clean this up a bit though. There probably won't be translations in `~/.local/share/imsprog`, although that's probably only cosmetic; you could conceivably do the lookups only once in main and stash some global state for the datafile location? Just thinking out loud.

This however is now (presumably) magic-free and accounts for all but one case (running IMSProg from the compile directory, although there may still be complications wrt. in-tree or out-of-tree builds), but you can add that if you wish.

A word of caution about `/usr/share/imsprog/IMSProg.Dat` (substitute for any system location). If and when packaged, a file in `/usr` (or any other system location of the sort) becomes set in stone - you don't update it, you don't modify it, nothing. There are complicated approaches, but I suggest the simplest way around this is to treat it as a "sample database" (might as well call it `IMSProg.Dat.sample` or something), and upon start, if `~/.local/share/imsprog/IMSProg.Dat` does not exist yet, copy it over, and only use the user-specific one.

This solves a lot of problems should IMSProg be packaged for Linux or BSDs or Homebrew or whatnot in the future.