### PR TITLE
Refactor path lookups

### DIFF
--- a/IMSProg_programmer/main.cpp
+++ b/IMSProg_programmer/main.cpp
@@ -14,8 +14,70 @@
  */
 #include "mainwindow.h"
 #include <QApplication>
-#include <QFileInfo>
+#include <QFile>
+#include <QDir>
 #include <QStandardPaths>
+#include <QTranslator>
+
+static QString setUpTranslation(const QStringList &searchPaths)
+{
+    QString localeName = QLocale::system().name();
+    QString translateName = "chipProgrammer_" + localeName;
+
+    // skip user-specific dir for translations (first one); try the rest
+    foreach (const QString &path, searchPaths.mid(1))
+    {
+        QTranslator *translator = new QTranslator(qApp);
+        if (translator->load(translateName, path))
+        {
+            qApp->installTranslator(translator);
+            qDebug() << "Installed" << translateName << "from" << path;
+            return path;
+        } else {
+            delete translator;
+        }
+    }
+
+    return QString();
+}
+
+static QString findSystemChipDBFile(const QStringList &searchPaths)
+{
+    foreach (const QString &path, searchPaths.mid(1))
+    {
+        QString chipdbfile = QDir(path).filePath("IMSProg.Dat");
+        if (QFile::exists(chipdbfile)) {
+            return chipdbfile;
+        }
+    }
+
+    return QString();
+}
+
+static void initPaths()
+{
+    QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
+    if (allPaths.isEmpty()) {
+        // do not translate
+        qFatal("Critical error: QStandardPaths::standardLocations(QStandardPaths::AppDataLocation): empty list");
+    }
+
+    QDir binDir(QCoreApplication::applicationDirPath());
+    QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
+    allPaths.insert(1, binRelPath);
+
+    QDir userAppDataLocation(allPaths.value(0));
+    if (!userAppDataLocation.exists()) {
+        userAppDataLocation.mkpath(".");
+        // XXX some sort of error handling that befits the application
+    }
+
+    qApp->setProperty("app/translationDirectory", setUpTranslation(allPaths));
+    qApp->setProperty("app/systemChipDatabaseFile", findSystemChipDBFile(allPaths));
+    qApp->setProperty("app/userChipDatabaseFile", userAppDataLocation.filePath("IMSProg.Dat"));
+    qApp->setProperty("app/userConfigFile", userAppDataLocation.filePath("IMSProg.Dat"));
+}
+
 
 int main(int argc, char *argv[])
 {
@@ -26,39 +88,8 @@ int main(int argc, char *argv[])
     font.setStyleHint(QFont::TypeWriter);
     font.setPointSize(12);
     QApplication::setFont(font);
-    QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    QDir binDir(QCoreApplication::applicationDirPath());
-    QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
-    allPaths.insert(1, QDir::cleanPath(binRelPath));
+    initPaths();
 
-    QString localeName = QLocale::system().name();
-    QString translateName = "chipProgrammer_" + localeName;
-    qDebug() << "localeName = " << localeName << ", translateName = " << translateName;
-
-    foreach (const QString &path, allPaths)
-    {
-        QString fullPath = QDir(path).filePath(translateName + ".qm");
-        qDebug() << "Trying " << fullPath;
-
-        if (QFile::exists(fullPath))
-        {
-            qDebug() << "Found translation file:" << fullPath;
-            QTranslator *translator = new QTranslator(&a);
-
-            if (translator->load(translateName, path))
-            {
-                a.installTranslator(translator);
-                qDebug() << "Installed" << translateName << "from" << path;
-                break;
-            }
-            else
-            {
-                delete translator; 
-            }
-        }
-    }
-
-    QStringList cmdline_args = QCoreApplication::arguments();
     MainWindow w;
     w.show();
 

--- a/IMSProg_programmer/mainwindow.cpp
+++ b/IMSProg_programmer/mainwindow.cpp
@@ -135,7 +135,7 @@ MainWindow::MainWindow(QWidget *parent) :
  oldChipData.fill(char(0xff));
 
  //Reading ini file
- QString iniPath = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("config.ini");
+ QString iniPath = qApp->property("app/userConfigFile").toString();
  qDebug() << "Using config file " << iniPath;
  if (QFileInfo(iniPath).exists())
  {
@@ -1997,29 +1997,14 @@ void MainWindow::progInit()
 {
     int index2;
     ui->statusMessage->setText(tr("Opening DAT file"));
+    QFile datfile(qApp->property("app/userChipDatabaseFile").toString());
 
-    QStringList allPaths = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-    QDir binDir(QCoreApplication::applicationDirPath());
-    QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
-    allPaths.insert(1, binRelPath);
-    // allPaths is now
-    // - user-specific directory
-    // - share directory relative to IMSProg executable
-    // - standard locations
-
-    // use the first chip database file found
-    QFile datfile;
-    foreach (const QString &dir, allPaths)
-    {
-        QString fullPath = QDir(dir).filePath("IMSProg.Dat");
-        if (QFile::exists(fullPath)) {
-            datfile.setFileName(fullPath);
-            break;
-        }
+    if (!datfile.exists()) {
+        datfile.setFileName(qApp->property("app/systemChipDatabaseFile").toString());
     }
-
-    if (datfile.fileName().isEmpty()) {
-        QMessageBox::about(this, tr("Error"), tr("The chip database file was not found!"));
+    if (!datfile.exists()) {
+        QString msg = tr("Cannot find a chip database file.\nYou may want to run IMSProg_database_update");
+        QMessageBox::about(this, tr("Error"), msg);
         return;
     }
 


### PR DESCRIPTION
Figure out all paths and file locations in one place, stash them as custom properties.

--

This is the last thing I had in mind here. The approach proposed here has the advantage of handling (figuring out, looking up, creating if necessary, as and when appropriate) all paths, files or directories (I think I didn't miss any?) and things in one place, immediately after startup. If say platform-specific muckery needs to be done or whatnot, it's all in one place.

Error handling is a bit of a how ya going, but a) if these things here fail, you have bigger problems :D, b) there are a couple of options I couldn't really decide between, so pick whichever is appropriate for the general flow.