### PR TITLE
(translation) PT-BR:  Modified 'não conectado' to 'desconectado'

### DIFF
--- a/IMSProg_programmer/language/chipProgrammer_pt_BR.ts
+++ b/IMSProg_programmer/language/chipProgrammer_pt_BR.ts
@@ -2082,7 +2082,7 @@ Buffer: </translation>
     <message>
         <location filename="../mainwindow.cpp" line="1565"/>
         <source>Not connected</source>
-        <translation>Não conectado</translation>
+        <translation>Desconectado</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1934"/>


### PR DESCRIPTION
Although 'não conectado' (not connected) is not wrong in brazilian portuguese, we have a better term for it which is 'desconectado'.

This term not only complies with the language norm but also fits better in the red box in the main window:


<img width="234" height="101" alt="2026-04-16_17-01" src="https://github.com/user-attachments/assets/bb7936ff-5948-4133-81e2-53e4d8cf17fb" />



References:
https://www.academia.org.br/nossa-lingua/busca-no-vocabulario (then type 'desconectado')
https://pt.wiktionary.org/wiki/desconectado