### PR TITLE
Use .at() instead of .value()

### DIFF
--- a/IMSProg_database_update/main.cpp
+++ b/IMSProg_database_update/main.cpp
@@ -56,7 +56,7 @@ static void initPaths()
     QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
     allPaths.insert(1, binRelPath);
 
-    QDir userAppDataLocation(allPaths.value(0));
+    QDir userAppDataLocation(allPaths.at(0));
     if (!userAppDataLocation.exists()) {
         userAppDataLocation.mkpath(".");
         // XXX some sort of error handling that befits the application

--- a/IMSProg_programmer/main.cpp
+++ b/IMSProg_programmer/main.cpp
@@ -66,7 +66,7 @@ static void initPaths()
     QString binRelPath = QDir::cleanPath(binDir.absoluteFilePath("../share/" + QCoreApplication::applicationName()));
     allPaths.insert(1, binRelPath);
 
-    QDir userAppDataLocation(allPaths.value(0));
+    QDir userAppDataLocation(allPaths.at(0));
     if (!userAppDataLocation.exists()) {
         userAppDataLocation.mkpath(".");
         // XXX some sort of error handling that befits the application


### PR DESCRIPTION
This is very minor improvement.

about QList::value(qsizetype i):
If you are certain that i is within bounds, you can use at() instead, which is slightly faster.

about QStandardPaths::AppDataLocation:
Returns a directory location where persistent application data can be stored. This is an application-specific directory. To obtain a path to store data to be shared with other applications, use QStandardPaths::GenericDataLocation. The returned path is never empty. On the Windows operating system, this returns the roaming path. This enum value was added in Qt 5.4.