### PR TITLE
Del non-ascii characters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,7 @@ code function.
 speed, and SPI NOR Flash erase speed. SPI NOR Flash write speed increased by
 30%. Incorrect chip page sizes values removed. Unused files removed.
 Translations updated.
-- Ver. 1.7.3 — When closing the program, the programmer type, chip image
+- Ver. 1.7.3 - When closing the program, the programmer type, chip image
 directory, and main window size are saved in the
 ~/.local/share/imsprog/settings.ini file. Fix: Incorrect HexEdit size when
 starting the program.

--- a/IMSProg_editor/ezp_chip_editor.cpp
+++ b/IMSProg_editor/ezp_chip_editor.cpp
@@ -74,7 +74,7 @@ void MainWindow::on_actionOpen_triggered()
 
     dataSize = data.length();
     ui->tableView->setShowGrid(true);
-    //Заголовки столбцов
+    //Column headings
     QStringList horizontalHeader;
     //horizontalHeader.append("No");
     horizontalHeader.append(tr("Type"));

--- a/IMSProg_programmer/ch347.h
+++ b/IMSProg_programmer/ch347.h
@@ -102,7 +102,7 @@ struct ch347_spi_hw_config {
     uint16_t SPI_CPOL;
     uint16_t SPI_CPHA;
     uint16_t SPI_NSS; /* hardware or software managed CS */
-    uint16_t SPI_BaudRatePrescaler; /* prescaler = x * 8. x: 0=60MHz, 1=30MHz, 2=15MHz, 3=7.5MHz, 4=3.75MHz, 5=1.875MHz, 6=937.5KHz，7=468.75KHz */
+    uint16_t SPI_BaudRatePrescaler; /* prescaler = x * 8. x: 0=60MHz, 1=30MHz, 2=15MHz, 3=7.5MHz, 4=3.75MHz, 5=1.875MHz, 6=937.5KHz, 7=468.75KHz */
     uint16_t SPI_FirstBit; /* MSB or LSB first */
     uint16_t SPI_CRCPolynomial; /* polynomial used for the CRC calculation. */
     uint16_t SPI_WriteReadInterval; /* No idea what this is... Original comment from WCH: SPI接口常规读取写入数据命令(DEF_CMD_SPI_RD_WR))，单位为uS */

--- a/IMSProg_programmer/other/index.html
+++ b/IMSProg_programmer/other/index.html
@@ -56,7 +56,7 @@
 <p>The IMSProg makes respect to <a href="https://github.com/Simsys/qhexedit2">QHexEdit2</a> hex editor and <a href="https://github.com/McMCCRU/SNANDer">SNANDer programmer</a>. The format of the chip database is based on the format used in EZP2019, EZP2020, EZP2023, Minpro I, XP866+ programmers. Warning, format is not the same!</p>
 <p>IMSProg is a collection of tools:</p>
 <ol type="1">
-<li><p>IMSProg - the chip programmer (it’s the main part).</p></li>
+<li><p>IMSProg - the chip programmer (it's the main part).</p></li>
 <li><p>IMSProg_editor - chip database editor.</p></li>
 <li><p>IMSProg_database_update - update chip database using external web-server.</p></li>
 </ol>
@@ -105,7 +105,7 @@ sudo zypper install libqt5-linguist-devel libusb-1_0-devel</code></pre>
 </ul>
 <blockquote>
 <p>[!NOTE] <em>In the current version, the MicroWire (93Cxx) protocol is not supported by the CH347 programming device.</em></p>
-<p><em>CH347T V1.1 — a device with a lower speed than the CH347T V1.0.</em></p>
+<p><em>CH347T V1.1 - a device with a lower speed than the CH347T V1.0.</em></p>
 </blockquote>
 <figure>
 <img src="93xxx_adapter.png" alt="" /><figcaption>Adapter</figcaption>
@@ -138,7 +138,7 @@ sudo zypper install libqt5-linguist-devel libusb-1_0-devel</code></pre>
 <li><p>Pressing <code>Read</code> or <img src="read64.png" alt="Read" /> or <code>&lt;Ctrl+R&gt;</code> to read data from the chip into the computer buffer.</p></li>
 <li><p>Pressing <img src="write64.png" alt="Write" /> or <code>&lt;Ctrl+W&gt;</code> to write data from the computer buffer into the chip.</p></li>
 <li><p>Pressing <img src="erase64.png" alt="Erase" /> or <code>&lt;Ctrl+E&gt;</code> will erase all data in the chip.</p></li>
-<li><p>By selecting ‘Main Menu -&gt; Chip -&gt; Check erase’ or pressing <code>&lt;Ctrl+J&gt;</code>, you can check whether all data has been correctly deleted from the chip.</p></li>
+<li><p>By selecting <code>Main Menu -&gt; Chip -&gt; Check erase</code> or pressing <code>&lt;Ctrl+J&gt;</code>, you can check whether all data has been correctly deleted from the chip.</p></li>
 <li><p>Pressing the <img src="verify64.png" alt="Verify" /> or <code>&lt;Ctrl+T&gt;</code> button causes the data in the chip and in the computer buffer to be compared.</p></li>
 </ul>
 <p>The progress bar shows the progress of the read, erase, and verify operations.</p>
@@ -322,8 +322,8 @@ sudo zypper install libqt5-linguist-devel libusb-1_0-devel</code></pre>
 <ul>
 <li><code>Delete Rows</code> or <code>Del</code> or <img src="del.png" alt="delete" /> - deletes one or more rows.</li>
 <li><code>Add Row</code> or <code>Ins</code> or <img src="plus.png" alt="add" /> - adds a row below the selected row and copies all data from the selected row to the new row.</li>
-<li><code>Move Up</code> or ’[Ctrl+Up]` or <img src="undo.png" alt="up" /> - moves the selected line up.</li>
-<li><code>Move Down' or</code>[Ctrl+Down]` or <img src="redo.png" alt="down" /> - moves the selected row down.</li>
+<li><code>Move Up</code> or `[Ctrl+Up]` or <img src="undo.png" alt="up" /> - moves the selected line up.</li>
+<li><code>Move Down</code> or `[Ctrl+Down]` or <img src="redo.png" alt="down" /> - moves the selected row down.</li>
 <li><code>Import selected rows to CSV format</code> or <img src="import.png" alt="import" /></li>
 <li>saves selected rows to CSV file.</li>
 </ul>
@@ -520,7 +520,7 @@ sudo zypper install libqt5-linguist-devel libusb-1_0-devel</code></pre>
 <h2 id="packages">Packages</h2>
 <ul>
 <li><p>There is a work in progress for add IMSProg to official <code>Debian</code> (and derivatives repositories)</p>
-<p>For some Ubuntu versions you can use this PPA by adding <code>ppa:bigmdm/imsprog</code> to your system’s Software Sources.</p>
+<p>For some Ubuntu versions you can use this PPA by adding <code>ppa:bigmdm/imsprog</code> to your system's Software Sources.</p>
 <pre><code>sudo add-apt-repository ppa:bigmdm/imsprog
 sudo apt update
 sudo apt install imsprog</code></pre>

--- a/IMSProg_programmer/spi_nor_flash.c
+++ b/IMSProg_programmer/spi_nor_flash.c
@@ -1096,7 +1096,7 @@ int nand_page_write(unsigned char *buf, unsigned int page_size, uint32_t sector_
     SPI_CONTROLLER_Chip_Select_Low(programmerType);
     retval = SPI_CONTROLLER_Write_NByte(cmdbuf, 3, SPI_CONTROLLER_SPEED_SINGLE, programmerType);
     if (retval == -1) return retval;
-    retval = SPI_CONTROLLER_Write_NByte(buf, page_size, SPI_CONTROLLER_SPEED_SINGLE, programmerType); //1010 page_size УБРАТЬ /8 !!!!
+    retval = SPI_CONTROLLER_Write_NByte(buf, page_size, SPI_CONTROLLER_SPEED_SINGLE, programmerType);
     if (retval == -1) return retval;
     SPI_CONTROLLER_Chip_Select_High(programmerType);
     nand_wait_ready(200);

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ adapter must be installed in the programmer slot marked `25xxx`.
 > *In the current version, the MicroWire (93Cxx) protocol is 
 not supported by the CH347 programming device.*
 >
-> *CH347T V1.1 — a device with a lower speed than the CH347T V1.0.*
+> *CH347T V1.1 - a device with a lower speed than the CH347T V1.0.*
 
 ![Adapter](img/93xxx_adapter.png)
  
@@ -209,7 +209,7 @@ computer buffer into the chip.
 - Pressing ![Erase](img/erase64.png) or `<Ctrl+E>` will erase all data in the 
 chip.
 
-- By selecting ‘Main Menu -> Chip -> Check erase’ or pressing `<Ctrl+J>`, you
+- By selecting `Main Menu -> Chip -> Check erase` or pressing `<Ctrl+J>`, you
  can check whether all data has been correctly deleted from the chip.
 
 - Pressing the ![Verify](img/verify64.png) or `<Ctrl+T>` button causes the 


### PR DESCRIPTION
This code was used to detect non-ascii characters
```
~/IMSProg$ fdfind -tf -E language -E imsprog.spec -E *.desktop -E img -E *.xml -E *.gz -E *.qrc -E *.Dat -X grep -HP '[^[:ascii:]]' "$PWD" | grep -v '⌘'
```
While doing this task I also found mistakes in index.html and fixed its.

I also deleted old [comment](https://github.com/bigbigmdm/IMSProg/commit/e996b4163f52720ee528f18b238b3f802ddb3964#commitcomment-184195811)