### PR TITLE
make correctChipTyte() more simple

### DIFF
--- a/IMSProg_editor/ezp_chip_editor.cpp
+++ b/IMSProg_editor/ezp_chip_editor.cpp
@@ -836,15 +836,8 @@ void MainWindow::on_actionImport_from_CSV_triggered()
 }
 bool MainWindow::correctChipTyte(QString str)
 {
-    bool ansver = false;
-    for (QString elem : chType)
-    {
-      if(str.compare(elem)==0)
-          {
-          ansver = true;
-          return ansver;
-          }
+    for (const QString &elem : std::as_const(chType)) {
+        if (str == elem) return true;
     }
-    return ansver;
-
+    return false;
 }


### PR DESCRIPTION
I think in next iteration we should switch to C++23, [example](https://www.jdoodle.com/online-compiler-c++23)
```
#include <iostream>
#include <algorithm>
#include <vector>

int main() {

    std::vector<int> v = {1, 2, 3};
    auto elem = 1;
    if (std::ranges::contains(v, elem)) {
        // Element found
        std::cout << "Element found";
    }else std::cout << "not found";

    return 0;
}
```