### PR TITLE
In Ubuntu 24.04 systemd-dev is valid dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On Debian and derivatives:
 `sudo apt-get install cmake g++ libusb-1.0-0-dev pkgconf qt6-base-dev qt6-tools-dev
  linguist-qt6 qt6-l10n-tools qt6-base-dev-tools qt6-tools-dev-tools`
 
-On Debian >=13 and Ubuntu >=23.10:
+On Debian >=13 and Ubuntu >=24.04:
 
 `sudo apt-get install systemd-dev`
 


### PR DESCRIPTION
You can check behavior
```
q@ubuntu-desktop:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.4 LTS
Release:	24.04
Codename:	noble
q@ubuntu-desktop:~$ sudo apt-get install cmake g++ libusb-1.0-0-dev pkgconf qt6-base-dev qt6-tools-dev linguist-qt6 qt6-l10n-tools qt6-base-dev-tools qt6-tools-dev-tools systemd-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
g++ is already the newest version (4:13.2.0-7ubuntu1).
g++ set to manually installed.
systemd-dev is already the newest version (255.4-1ubuntu8.15).
systemd-dev set to manually installed.
The following additional packages will be installed:
  assistant-qt6 cmake-data designer-qt6 libb2-1 libclang-cpp15t64
  libclang1-15t64 libdouble-conversion3 libgumbo2 libjsoncpp25 liblitehtml0t64
  libllvm15t64 libmd4c0 libpcre2-16-0 libpkgconf3 libqt6concurrent6t64
  libqt6core6t64 libqt6dbus6t64 libqt6designer6 libqt6designercomponents6
  libqt6gui6t64 libqt6help6 libqt6network6t64 libqt6opengl6t64
  libqt6openglwidgets6t64 libqt6printsupport6t64 libqt6qml6 libqt6qmlmodels6
  libqt6quick6 libqt6quickwidgets6 libqt6sql6-sqlite libqt6sql6t64
  libqt6test6t64 libqt6uitools6 libqt6waylandclient6 libqt6waylandcompositor6
  libqt6waylandeglclienthwintegration6
  libqt6waylandeglcompositorhwintegration6 libqt6widgets6t64
  libqt6wlshellintegration6 libqt6xml6t64 librhash0 libts0t64 libusb-1.0-doc
  libvulkan-dev pkgconf-bin qdbus-qt6 qmake6 qmake6-bin
  qt6-documentation-tools qt6-gtk-platformtheme qt6-qpa-plugins
  qt6-translations-l10n qt6-wayland
Suggested packages:
  cmake-doc cmake-format elpa-cmake-mode ninja-build qt6-qmltooling-plugins
The following NEW packages will be installed:
  assistant-qt6 cmake cmake-data designer-qt6 libb2-1 libclang-cpp15t64
  libclang1-15t64 libdouble-conversion3 libgumbo2 libjsoncpp25 liblitehtml0t64
  libllvm15t64 libmd4c0 libpcre2-16-0 libpkgconf3 libqt6concurrent6t64
  libqt6core6t64 libqt6dbus6t64 libqt6designer6 libqt6designercomponents6
  libqt6gui6t64 libqt6help6 libqt6network6t64 libqt6opengl6t64
  libqt6openglwidgets6t64 libqt6printsupport6t64 libqt6qml6 libqt6qmlmodels6
  libqt6quick6 libqt6quickwidgets6 libqt6sql6-sqlite libqt6sql6t64
  libqt6test6t64 libqt6uitools6 libqt6waylandclient6 libqt6waylandcompositor6
  libqt6waylandeglclienthwintegration6
  libqt6waylandeglcompositorhwintegration6 libqt6widgets6t64
  libqt6wlshellintegration6 libqt6xml6t64 librhash0 libts0t64 libusb-1.0-0-dev
  libusb-1.0-doc libvulkan-dev linguist-qt6 pkgconf pkgconf-bin qdbus-qt6
  qmake6 qmake6-bin qt6-base-dev qt6-base-dev-tools qt6-documentation-tools
  qt6-gtk-platformtheme qt6-l10n-tools qt6-qpa-plugins qt6-tools-dev
  qt6-tools-dev-tools qt6-translations-l10n qt6-wayland
0 upgraded, 62 newly installed, 0 to remove and 16 not upgraded.
```