### PR TITLE
[doc] remove how to build

### DIFF
--- a/IMSProg_editor/README.md
+++ b/IMSProg_editor/README.md
@@ -20,13 +20,3 @@ If you want convert all strings in to .CSV file use the `Export to CSV` ![tocsv]
 If you want import .CSV database in to program use `Import from CSV` ![import](img/import.png) in `File` menu.
 
 Any cell is editable.
-
-## Building
-
-```
-mkdir build
-cd build
-cmake ..
-make -j4
-sudo make install
-```


### PR DESCRIPTION
This is more question. Let's remove how to build info? Because we have [build_all.sh](https://github.com/AndreiCherniaev/IMSProg_dev/blob/main/build_all.sh)