### PR TITLE
Fix Qt6

### DIFF
--- a/IMSProg_database_update/CMakeLists.txt
+++ b/IMSProg_database_update/CMakeLists.txt
@@ -131,7 +131,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 if (QT_VERSION_MAJOR EQUAL 5)
     target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Widgets Qt5::Network)
 else()
-    target_link_libraries(${PROJECT_NAME} Qt::Core Qt::Widgets Qt::Network)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets Qt::Network)
 endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/IMSProg_editor/CMakeLists.txt
+++ b/IMSProg_editor/CMakeLists.txt
@@ -130,7 +130,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 if (QT_VERSION_MAJOR EQUAL 5)
     target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Widgets)
 else()
-    target_link_libraries(${PROJECT_NAME} Qt::Core Qt::Widgets)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)
 endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/IMSProg_programmer/CMakeLists.txt
+++ b/IMSProg_programmer/CMakeLists.txt
@@ -240,7 +240,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${LIBUSB_INCLUDE_DIRS}")
 if (QT_VERSION_MAJOR EQUAL 5)
     target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Widgets ${LIBUSB_LIBRARIES})
 else()
-    target_link_libraries(${PROJECT_NAME} Qt::Core Qt::Widgets ${LIBUSB_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets ${LIBUSB_LIBRARIES})
 endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Qt recommends and uses the PRIVATE keyword in target_link_libraries because it restricts the dependency's scope to the internal implementation of your target, preventing unintended dependency bloat for downstream consumers. This practice enforces tight encapsulation and represents modern CMake best practices.