### PR TITLE
Use app dir for IMSProg.Dat and defaultPath on Windows

### DIFF
--- a/IMSProg_editor/ezp_chip_editor.cpp
+++ b/IMSProg_editor/ezp_chip_editor.cpp
@@ -39,11 +39,19 @@ void MainWindow::on_actionOpen_triggered()
 {
     QString fileName, benchmarkDataFile, currentPath;
     char txtBuf[0x30];
+    #ifdef _WIN32
+    benchmarkDataFile = QCoreApplication::applicationDirPath() + "/IMSProg.Dat";
+    #else
     benchmarkDataFile = "/usr/share/imsprog/IMSProg.Dat";
+    #endif
     QFileInfo check_benchmarkDataFile(benchmarkDataFile);
     int i, j, recNo, dataPoz, dataSize, chipSize, blockSize, delay, rowCount;
     unsigned char chipSizeCode, chipID, manCode, tmpBuf;
+    #ifdef _WIN32
+    defaultPath = QCoreApplication::applicationDirPath();
+    #else
     defaultPath = QDir::homePath() + "/.local/share/imsprog/";
+    #endif
     // if ~//.local/share/imsprog/ is not exists opening file from /usr/share/imsprog/
     if (!QDir(defaultPath).exists())  currentPath = benchmarkDataFile;
     else currentPath = defaultPath;


### PR DESCRIPTION
Add `_WIN32` guards so on Windows the code uses `QCoreApplication::applicationDirPath()` for `benchmarkDataFile` and `defaultPath`.

Non-Windows builds keep using `/usr/share/imsprog/IMSProg.Dat` and `~/.local/share/imsprog/`.

This makes Windows builds use the application directory instead of Linux-specific paths.

Portable Windows Application